### PR TITLE
Removed "China is overtaking the US in scientific research." entry as it is (now) paywalled

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
 		<ul>
 			<li><a target="_blank" href="https://nautil.us/issue/62/systems/eating-for-peace">Eating for peace: how cuisine bridges cultures.</a></li>
 			<li><a target="_blank" href="https://www.chronicle.com/article/How-Political-Science-Became/245777">How Political Science became irrelevant.</a></li>
-			<li><a target="_blank" href="https://www.bloomberg.com/opinion/articles/2018-09-12/chinese-researchers-are-outperforming-americans-in-science">China is overtaking the US in scientific research.</a></li>
 			<li><a target="_blank" href="https://theconversation.com/with-cryptocurrency-launch-facebook-sets-its-path-toward-becoming-an-independent-nation-118987">Facebook is becoming an «independent nation».</a></li>
 			<!--
 			<li><a target="_blank" href="https://www.caixinglobal.com/2019-08-06/chinese-farmers-are-growing-soybeans-in-russia-as-china-substitutes-us-suppliers-101448063.html">Chinese farmers are growing soybeans in Russia as China substitutes U.S. suppliers.</a></li>


### PR DESCRIPTION
https://www.bloomberg.com/opinion/articles/2018-09-12/chinese-researchers-are-outperforming-americans-in-science is now paywalled.