### PR TITLE
my attempt for dark mode

### DIFF
--- a/assets/slowernews.css
+++ b/assets/slowernews.css
@@ -1,12 +1,24 @@
-html {
+:root {
   font-size: 15px;
+  --bg: #fffff8;
+  --fg: #111;
+  --recent: red;
+  --greatLink: brown;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #20201e;
+    --fg: #d0cac1;
+    --recent: #ff6060;
+    --greatLink: #b39292;
+  }
+}
 
 /* LAYOUT */
 body {
-  background-color: #fffff8;
-  color: #111;
+  background-color: var(--bg);
+  color: var(--fg);
   font-family: et-book, serif;
   margin: 0 auto;
   max-width: 1280px;
@@ -94,10 +106,10 @@ hr {
   padding: 0;
 }
 .recent {
-  color: red;
+  color: var(--recent);
 }
 .greatLink {
-  color: brown;
+  color: var(--greatLink);
   font-size: 1.25rem;
 }
 .fullwidth {
@@ -134,16 +146,16 @@ a:link {
 }
 a:visited {
   color: grey;
-} 
+}
 a:link {
   text-decoration: none;
-  background: -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(#fffff8, #fffff8), -webkit-linear-gradient(currentColor, currentColor);
-  background: linear-gradient(#fffff8, #fffff8), linear-gradient(#fffff8, #fffff8), linear-gradient(currentColor, currentColor);
+  background: -webkit-linear-gradient(var(--bg), var(--bg)), -webkit-linear-gradient(var(--bg), var(--bg)), -webkit-linear-gradient(currentColor, currentColor);
+  background: linear-gradient(var(--bg), var(--bg)), linear-gradient(var(--bg), var(--bg)), linear-gradient(currentColor, currentColor);
   -webkit-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
   -moz-background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
   background-size: 0.05em 1px, 0.05em 1px, 1px 1px;
   background-repeat: no-repeat, no-repeat, repeat-x;
-  text-shadow: 0.03em 0 #fffff8, -0.03em 0 #fffff8, 0 0.03em #fffff8, 0 -0.03em #fffff8, 0.06em 0 #fffff8, -0.06em 0 #fffff8, 0.09em 0 #fffff8, -0.09em 0 #fffff8, 0.12em 0 #fffff8, -0.12em 0 #fffff8, 0.15em 0 #fffff8, -0.15em 0 #fffff8;
+  text-shadow: 0.03em 0 var(--bg), -0.03em 0 var(--bg), 0 0.03em var(--bg), 0 -0.03em var(--bg), 0.06em 0 var(--bg), -0.06em 0 var(--bg), 0.09em 0 var(--bg), -0.09em 0 var(--bg), 0.12em 0 var(--bg), -0.12em 0 var(--bg), 0.15em 0 var(--bg), -0.15em 0 var(--bg);
   background-position: 0% 93%, 100% 93%, 0% 93%;
 }
 
@@ -156,6 +168,6 @@ a:link {
 
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
   a:link {
-	background-position-y: 87%, 87%, 87%;
+    background-position-y: 87%, 87%, 87%;
   }
 }


### PR DESCRIPTION
I attempted to realize a full dark mode for Slowernews. I think the former issues where mainly because of some assumption that the colours are changed by the system. That is not the case. This commit suggests an adapted colour set for darkmode. Devices that natively support that and works also in browsers on Linux where a flag needs to be set, see for example [this answer on Stackoverflow](https://stackoverflow.com/questions/56401662/firefox-how-to-test-prefers-color-scheme#56757527). I also paid attention to the contrast ratio rating to be at least AA for every colour.
![image](https://user-images.githubusercontent.com/246402/100471972-a4747a00-30db-11eb-9524-9f3babe92f3a.png)
