### PR TITLE
Removing vaunt article as it was discontinued

### DIFF
--- a/index.html
+++ b/index.html
@@ -395,7 +395,6 @@
 			<li><a href="https://www.raspberrypi.org/blog/raspberry-pi-400-the-70-desktop-pc/">Using a Raspberry Pi 400</a> or a <a href="https://hicksdesign.co.uk/journal/using-the-ipad-pro-as-my-main-computer">iPad Pro as my main computer.</a></li>
 			<li><a href="https://www.theguardian.com/technology/2015/nov/29/arm-cambridge-britain-tech-company-iphone">How ARM got so successful without the public really noticing.</a> | <span class="recent"><a href="https://www.singhkays.com/blog/apple-silicon-m1-black-magic/">Apple M1</a></span> | <span class="recent"><a href="https://jamesallworth.medium.com/intels-disruption-is-now-complete-d4fa771f0f2c">Intel’s disruption is now complete.</a></span></li>
 			<li><a href="https://github.com/alevchuk/vim-clutch">Vim clutch: hardware pedal for improved text editing speed.</a></li>
-			<li><a href="https://www.theverge.com/2018/2/5/16966530/intel-vaunt-smart-glasses-announced-ar-video">Smart glasses that look normal.</a></li>
 		</ul>
 	</section>
 

--- a/rationales/rationale-index.md
+++ b/rationales/rationale-index.md
@@ -8,3 +8,10 @@ Why articles were included, replaced or deprecated. Newer changes on top.
 
 - More centrist view on the [«Progressive Purge»](https://www.allsides.com/news/2021-01-11-0639/progressive-purge-begins).
 - Articles in [Democracy section](https://www.slowernews.com#democracy) were reordered to include this idea.
+
+### Smart glasses that look normal
+
+2021-01-19
+
+- Deprecating [Intel Vaunt smart glasses](https://www.theverge.com/2018/2/5/16966530/intel-vaunt-smart-glasses-announced-ar-video)
+- Vaunt was discontinued as [Intel confirmed that it plans to shut down the New Devices Group (NDG) and cease development of its smart glasses](https://www.theverge.com/2018/4/18/17255354/intel-vaunt-shut-down)


### PR DESCRIPTION
Removing Vaunt article as it was discontinued.

Added rationale with reference to article explaining Intel's reason for discontinuing it, as they plan to shut down the New Devices Group (NDG) and cease development of its smart glasses

source: <https://www.theverge.com/2018/4/18/17255354/intel-vaunt-shut-down>